### PR TITLE
[update] windows support

### DIFF
--- a/cmd/flag_config_dir.go
+++ b/cmd/flag_config_dir.go
@@ -1,17 +1,21 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+
 	"github.com/gabe565/gh-profile/internal/github"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"path/filepath"
 )
 
 func flagConfigDir(cmd *cobra.Command) {
 	defaultDir := os.Getenv("GH_CONFIG_DIR")
 	if defaultDir == "" {
-		if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		if runtime.GOOS == "windows" {
+			defaultDir = filepath.Join("$HOME", "AppData", "Roaming", "GitHub CLI")
+		} else if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
 			defaultDir = filepath.Join(xdgConfigHome, "gh")
 		} else {
 			defaultDir = filepath.Join("$HOME", ".config", "gh")


### PR DESCRIPTION
## [What this PR enables]

With this PR, gh-profile can be used in the Windows environment.

```go
if runtime.GOOS == "windows" {
	defaultDir = filepath.Join("$HOME", "AppData", "Roaming", "GitHub CLI")
```